### PR TITLE
Eliminate most allocations

### DIFF
--- a/WaveFormRendererLib/AveragePeakProvider.cs
+++ b/WaveFormRendererLib/AveragePeakProvider.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Linq;
 
 namespace NAudio.WaveFormRenderer
 {
-    public class AveragePeakProvider : PeakProvider
+    public sealed class AveragePeakProvider : PeakProvider
     {
         private readonly float scale;
 
@@ -15,8 +14,8 @@ namespace NAudio.WaveFormRenderer
         public override PeakInfo GetNextPeak()
         {
             var samplesRead = Provider.Read(ReadBuffer, 0, ReadBuffer.Length);
-            var sum = (samplesRead == 0) ? 0 : ReadBuffer.Take(samplesRead).Select(s => Math.Abs(s)).Sum();
-            var average = sum/samplesRead;
+            var sum = (samplesRead == 0) ? 0 : ReadBuffer.AsSpan(0, samplesRead).SumOfAbsoluteValues();
+            var average = sum / samplesRead;
             
             return new PeakInfo(average * (0 - scale), average * scale);
         }

--- a/WaveFormRendererLib/DecibelPeakProvider.cs
+++ b/WaveFormRendererLib/DecibelPeakProvider.cs
@@ -3,7 +3,7 @@ using NAudio.Wave;
 
 namespace NAudio.WaveFormRenderer
 {
-    class DecibelPeakProvider : IPeakProvider
+    sealed class DecibelPeakProvider : IPeakProvider
     {
         private readonly IPeakProvider sourceProvider;
         private readonly double dynamicRange;

--- a/WaveFormRendererLib/MathHelper.cs
+++ b/WaveFormRendererLib/MathHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace NAudio.WaveFormRenderer
+{
+    internal static class MathHelper
+    {
+        public static float SumOfAbsoluteValues(this Span<float> samples)
+        {
+            float result = 0;
+
+            for (int i = 0; i < samples.Length; i++)
+            {
+                result += Math.Abs(samples[i]);
+            }
+
+            return result;
+        }
+
+        public static float Min(this Span<float> samples)
+        {
+            float result = samples[0];
+
+            for (int i = 1; i < samples.Length; i++)
+            {
+                if (samples[i] < result)
+                {
+                    result = samples[i];
+                }
+            }
+
+            return result;
+        }
+
+        public static float Max(this Span<float> samples)
+        {
+            float result = samples[0];
+
+            for (int i = 1; i < samples.Length; i++)
+            {
+                if (samples[i] > result)
+                {
+                    result = samples[i];
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/WaveFormRendererLib/MaxPeakProvider.cs
+++ b/WaveFormRendererLib/MaxPeakProvider.cs
@@ -1,14 +1,14 @@
-﻿using System.Linq;
+﻿using System;
 
 namespace NAudio.WaveFormRenderer
 {
-    public class MaxPeakProvider : PeakProvider
+    public sealed class MaxPeakProvider : PeakProvider
     {
         public override PeakInfo GetNextPeak()
         {
             var samplesRead = Provider.Read(ReadBuffer,0,ReadBuffer.Length);
-            var max = (samplesRead == 0) ? 0 : ReadBuffer.Take(samplesRead).Max();
-            var min = (samplesRead == 0) ? 0 : ReadBuffer.Take(samplesRead).Min();
+            var max = (samplesRead == 0) ? 0 : ReadBuffer.AsSpan(0, samplesRead).Max();
+            var min = (samplesRead == 0) ? 0 : ReadBuffer.AsSpan(0, samplesRead).Min();
             return new PeakInfo(min, max);
         }
     }

--- a/WaveFormRendererLib/PeakInfo.cs
+++ b/WaveFormRendererLib/PeakInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace NAudio.WaveFormRenderer
 {
-    public class PeakInfo
+    public readonly struct PeakInfo
     {
         public PeakInfo(float min, float max)
         {
@@ -8,7 +8,8 @@
             Min = min;
         }
 
-        public float Min { get; private set; }
-        public float Max { get; private set; }
+        public float Min { get; }
+
+        public float Max { get; }
     }
 }

--- a/WaveFormRendererLib/RmsPeakProvider.cs
+++ b/WaveFormRendererLib/RmsPeakProvider.cs
@@ -2,7 +2,7 @@
 
 namespace NAudio.WaveFormRenderer
 {
-    public class RmsPeakProvider : PeakProvider
+    public sealed class RmsPeakProvider : PeakProvider
     {
         private readonly int blockSize;
 
@@ -28,7 +28,7 @@ namespace NAudio.WaveFormRenderer
                 max = Math.Max(max, rms);
             }
 
-            return new PeakInfo(0 -max, max);
+            return new PeakInfo(0 - max, max);
         }
     }
 }

--- a/WaveFormRendererLib/SamplingPeakProvider.cs
+++ b/WaveFormRendererLib/SamplingPeakProvider.cs
@@ -2,7 +2,7 @@
 
 namespace NAudio.WaveFormRenderer
 {
-    public class SamplingPeakProvider : PeakProvider
+    public sealed class SamplingPeakProvider : PeakProvider
     {
         private readonly int sampleInterval;
 

--- a/WaveFormRendererLib/WaveFormRendererLib.csproj
+++ b/WaveFormRendererLib/WaveFormRendererLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>1.0.0</Version>
+		<Version>2.0.0</Version>
 		<Authors>Mark Heath</Authors>
 		<Description>WaveForm rendering component</Description>
 		<PackageProjectUrl>https://github.com/naudio/NAudio.WaveFormRenderer</PackageProjectUrl>
@@ -13,11 +13,12 @@
 		<AssemblyName>NAudio.WaveFormRenderer</AssemblyName>
 		<GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<LangVersion>8.0</LangVersion>
+		<LangVersion>9</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="NAudio" Version="2.0.0" />
-		<PackageReference Include="System.Drawing.Common" Version="5.0.1" />
+		<PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+		<PackageReference Include="System.Memory" Version="4.5.4" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR eliminates the use of Linq & changes PeakInfo to a struct to eliminate most allocations.