### PR TITLE
added support to render wavestream directly

### DIFF
--- a/WaveFormRendererLib/WaveFormRenderer.cs
+++ b/WaveFormRendererLib/WaveFormRenderer.cs
@@ -24,6 +24,19 @@ namespace NAudio.WaveFormRenderer
             }
         }
 
+        public Image Render(WaveStream data, WaveFormRendererSettings settings)
+            => Render(data, new MaxPeakProvider(), settings);
+
+        public Image Render(WaveStream data, IPeakProvider peakProvider, WaveFormRendererSettings settings)
+        {
+            int bytesPerSample = (data.WaveFormat.BitsPerSample / 8);
+            var samples = data.Length / (bytesPerSample);
+            var samplesPerPixel = (int)(samples / settings.Width);
+            var stepSize = settings.PixelsPerPeak + settings.SpacerPixels;
+            peakProvider.Init(new WaveStreamToSampleProviderAdapter(data), samplesPerPixel * stepSize);
+            return Render(peakProvider, settings);
+        }
+
         private static Image Render(IPeakProvider peakProvider, WaveFormRendererSettings settings)
         {
             if (settings.DecibelScale)

--- a/WaveFormRendererLib/WaveStreamToSampleProviderAdapter.cs
+++ b/WaveFormRendererLib/WaveStreamToSampleProviderAdapter.cs
@@ -1,0 +1,34 @@
+﻿using NAudio.Wave;
+using System;
+
+namespace NAudio.WaveFormRenderer
+{
+    public class WaveStreamToSampleProviderAdapter : ISampleProvider
+    {
+        private readonly WaveStream stream;
+
+        public WaveStreamToSampleProviderAdapter(WaveStream stream) => this.stream = stream;
+
+        public WaveFormat WaveFormat => stream.WaveFormat;
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            const int fSize = sizeof(float);
+            //Reserve a byte buffer with space for all needed floats
+            byte[] byteData = new byte[count * fSize];
+            
+            //Try to read the wanted amount
+            var actuallyRead = stream.Read(byteData, 0, byteData.Length);
+
+            //If we read less, change the wanted amount to the present amount of data
+            count = actuallyRead / fSize;
+
+            //convert everything
+            for(int i = 0; i < count; i++)
+                buffer[i + offset] = BitConverter.ToSingle(byteData, i * fSize);
+
+            //return the actual read
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
I've added the support to render data, that is already present in memory (as a `WaveStream`). 