### PR TITLE
Fixed an issue where block sizes of .wav files were set incorrectly in some cases.

### DIFF
--- a/WaveFormRendererLib/WaveFormRenderer.cs
+++ b/WaveFormRendererLib/WaveFormRenderer.cs
@@ -17,7 +17,8 @@ namespace NAudio.WaveFormRenderer
             var samples = waveStream.Length / (bytesPerSample);
             var samplesPerPixel = (int)(samples / settings.Width);
             var stepSize = settings.PixelsPerPeak + settings.SpacerPixels;
-            peakProvider.Init(waveStream.ToSampleProvider(), samplesPerPixel * stepSize);
+            //using samplesPerPixel * stepSize only  may throw an Exception when rendering from .wav files (due to incorrect block length)
+            peakProvider.Init(waveStream.ToSampleProvider(), samplesPerPixel * stepSize - samplesPerPixel * stepSize % waveStream.WaveFormat.BlockAlign);
             return Render(peakProvider, settings);
         }
 


### PR DESCRIPTION
Processing .wav files sometimes returned wrong block sizes when the render width was changed, resulting in an unhandled exception.